### PR TITLE
Added an option to remove sucessfully ripped tracks from a playlist 

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Spotify-ripper is a small ripper script for Spotify that rips Spotify URIs to MP
 
 * options for interactive login (no password in shell history) and relogin using previous credentials
 
+* option to remove tracks from playlist after successful ripping
+
 ## Usage
 
 ```shell
@@ -48,6 +50,8 @@ optional arguments:
   -m, --pcm             Saves a .pcm file with the raw PCM data
   -o, --overwrite       Overwrite existing MP3 files [Default=skip]
   -v VBR, --vbr VBR     Lame VBR encoding quality setting [Default=0]
+  -r, --remove-from-playlist
+                        Delete tracks from playlist after successful ripping [Default=no]
 
 Example usage:
     rip a single file: ./ripper.py -u user -p password spotify:track:52xaypL0Kjzk0ngwv3oBPR

--- a/ripper.py
+++ b/ripper.py
@@ -156,7 +156,7 @@ class Ripper(threading.Thread):
                 continue
 
         # actually removing the tracks from playlist
-        if args.remove_from_playlist and self.current_playlist:
+        if args.remove_from_playlist and self.current_playlist and len(self.tracks_to_remove):
             print(Fore.YELLOW + "Removing successfully ripped tracks from playlist " +
                     self.current_playlist.name + "..." + Fore.RESET)
 

--- a/ripper.py
+++ b/ripper.py
@@ -52,6 +52,7 @@ class Ripper(threading.Thread):
     pipe = None
     ripping = False
     finished = False
+    current_playlist = None
     end_of_track = threading.Event()
 
     def __init__(self, args):
@@ -102,7 +103,7 @@ class Ripper(threading.Thread):
             tracks = self.search_query(args.uri)
 
         # ripping loop
-        for track in tracks:
+        for idx,track in tracks:
             try:
                 print('Loading track...')
                 track.load()
@@ -129,6 +130,12 @@ class Ripper(threading.Thread):
                 self.end_progress()
                 self.finish_rip(track)
                 self.set_id3_and_cover(track)
+
+                if args.remove_from_playlist and self.current_playlist:
+                    print(Fore.YELLOW + "Removing track from playlist " + self.current_playlist.name + Fore.RESET)
+                    self.current_playlist.remove_tracks(idx)
+                    print('-'*79 + '\n');
+
             except spotify.Error as e:
                 print(Fore.RED + "Spotify error detected" + Fore.RESET)
                 self.logger.error(e)
@@ -145,26 +152,31 @@ class Ripper(threading.Thread):
         link = self.session.get_link(uri)
         if link.type == spotify.LinkType.TRACK:
             track = link.as_track()
-            return iter([track])
-        elif link.type == spotify.LinkType.PLAYLIST or link.type == spotify.LinkType.STARRED:
-            playlist = link.as_playlist()
+            return enumerate([track])
+        elif link.type == spotify.LinkType.PLAYLIST:
+            self.current_playlist = link.as_playlist()
             print('Loading playlist...')
-            playlist.load()
-            return iter(playlist.tracks)
+            self.current_playlist.load()
+            return enumerate(self.current_playlist.tracks)
+        elif link.type == spotify.LinkType.STARRED:
+            starred = link.as_playlist()
+            print('Loading starred playlist...')
+            starred.load()
+            return enumerate(starred.tracks)
         elif link.type == spotify.LinkType.ALBUM:
             album = link.as_album()
             print('Loading album...')
             album.load()
             album_browser = album.browse()
             album_browser.load()
-            return iter(album_browser.tracks)
+            return enumerate(album_browser.tracks)
         elif link.type == spotify.LinkType.ARTIST:
             artist = link.as_artist()
             print('Loading artist...')
             artist.load()
             artist_browser = artist.browse()
             artist_browser.load()
-            return iter(artist_browser.tracks)
+            return enumerate(artist_browser.tracks)
         return iter([])
 
     def search_query(self, query):
@@ -369,6 +381,7 @@ if __name__ == '__main__':
     parser.add_argument('-o', '--overwrite', action='store_true', help='Overwrite existing MP3 files [Default=skip]')
     parser.add_argument('-s', '--strip-colors', action='store_true', help='Strip coloring from output[Default=colors]')
     parser.add_argument('-v', '--vbr', default='0', help='Lame VBR encoding quality setting [Default=0]')
+    parser.add_argument('-r', '--remove-from-playlist', action='store_true', help='Delete tracks from playlist after successful ripping [Default=no]')
     parser.add_argument('uri', help='Spotify URI (either URI, a file of URIs or a search query)')
     args = parser.parse_args()
 


### PR DESCRIPTION
This is the first time I do python programming, so bear with me ;).

This pull request adds an option to remove the tracks that were ripped successfully from the playlist. 

Adding this was harder than I thought since

* `pyspotify` does not allow to remove a track object; only the playlist index. Therefore, I had to change the iterator to an enumerate to keep the index in the main loop
* `playlist.remove_tracks` seems to be called immediately. Therefore, I could not simply call it in the end of the loop but had to remove the tracks after everything is done

There is also one TODO comment in the code. I think python re-evaluates the statement below in the while loop, but I am unsure (first time writing python, remember?) since changes were always committed directly during my tests. We may discuss this here of you can simply remove the TODO if you think that this is the way to go :) 