### PR TITLE
Playlist file handling

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,8 +49,8 @@ Command Line
 
     usage: spotify-ripper [-h] [-S SETTINGS] [-a] [-A] [-b {160,320,96}] [-c]
                           [-d DIRECTORY] [-f] [-F] [-g {artist,album}] [-k KEY]
-                          [-u USER] [-p PASSWORD] [-l] [-L LOG] [-m] [-o] [-s]
-                          [-v VBR] [-V] [-r]
+                          [-u USER] [-p PASSWORD] [-l] [-L LOG] [-m] [-o]
+                          [-P] [-s] [-v VBR] [-V] [-r]
                           uri
 
     Rips Spotify URIs to MP3s with ID3 tags and album covers
@@ -82,6 +82,7 @@ Command Line
       -L LOG, --log LOG     Log in a log-friendly format to a file (use - to log to stdout)
       -m, --pcm             Saves a .pcm file with the raw PCM data
       -o, --overwrite       Overwrite existing MP3 files [Default=skip]
+      -P, --playlist        Store playlist in separate directories and keep track of changes
       -s, --strip-colors    Strip coloring from output[Default=colors]
       -v VBR, --vbr VBR     Lame VBR encoding quality setting [Default=0]
       -V, --version         show program's version number and exit
@@ -129,6 +130,8 @@ Prerequisites
 -  `mutagen <https://mutagen.readthedocs.org/en/latest/>`__
 
 -  `colorama <https://pypi.python.org/pypi/colorama>`__
+
+- `requests`__
 
 Mac OS X
 ~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 spotify-ripper |Version|
 ========================
 
-A fork of
+A fork of a fork of
 `spotify-ripper <https://github.com/robbeofficial/spotifyripper>`__ that
 uses `pyspotify <https://github.com/mopidy/pyspotify>`__ v2.x
 

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ URIs to MP3 files and includes ID3 tags and cover art.
 
 **Note that stream ripping violates the libspotify's ToS**
 
-**Hometaping kill music**
+**Hometaping kills music**
 
 Features
 --------

--- a/README.rst
+++ b/README.rst
@@ -10,6 +10,8 @@ URIs to MP3 files and includes ID3 tags and cover art.
 
 **Note that stream ripping violates the libspotify's ToS**
 
+**Hometaping kill music**
+
 Features
 --------
 
@@ -132,60 +134,6 @@ Prerequisites
 -  `colorama <https://pypi.python.org/pypi/colorama>`__
 
 - `requests`__
-
-Mac OS X
-~~~~~~~~
-
-Recommend approach uses `homebrew <http://brew.sh/>`__ and
-`pyenv <https://github.com/yyuu/pyenv>`__
-
-.. code:: bash
-
-    $ brew install homebrew/binary/libspotify
-    $ sudo ln -s /usr/local/opt/libspotify/lib/libspotify.12.1.51.dylib \
-        /usr/local/opt/libspotify/lib/libspotify
-    $ brew install lame
-    $ pip install spotify-ripper
-    $ pyenv rehash
-
-Download an application key file ``spotify_appkey.key`` from
-``https://devaccount.spotify.com/my-account/keys/`` (requires a Spotify
-Premium Account) and move the file to the ``~/.spotify-ripper`` directory (or use
-the ``-k | --key`` option).
-
-Ubuntu/Debian
-~~~~~~~~~~~~~
-
-Recommend approach uses `pyenv <https://github.com/yyuu/pyenv>`__. If
-you don't use pyenv, you need to install the ``python-dev`` package
-too. If you are installing on the Raspberry Pi (gen 1), use the
-`eabi-armv6hf
-version <https://developer.spotify.com/download/libspotify/libspotify-12.1.103-Linux-armv6-bcm2708hardfp-release.tar.gz>`__
-of libspotify.
-
-.. code:: bash
-
-    $ sudo apt-get install lame build-essential libffi-dev
-    $ wget https://developer.spotify.com/download/libspotify/libspotify-12.1.51-Linux-x86_64-release.tar.gz # (assuming 64-bit)
-    $ tar xvf libspotify-12.1.51-Linux-x86_64-release.tar.gz
-    $ cd libspotify-12.1.51-Linux-x86_64-release/
-    $ sudo make install prefix=/usr/local
-    $ pip install spotify-ripper
-    $ pyenv rehash
-
-Download an application key file ``spotify_appkey.key`` from
-``https://devaccount.spotify.com/my-account/keys/`` (requires a Spotify
-Premium Account) and move the file to the ``~/.spotify-ripper`` directory (or use
-the ``-k | --key`` option).
-
-Upgrade
-~~~~~~~
-
-Use ``pip`` to upgrade to the latest version.
-
-.. code:: bash
-
-    $ pip install --upgrade spotify-ripper
 
 License
 -------

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
-spotify-ripper |Version|
-========================
+spotify-ripper
+==============
 
 A fork of a fork of
 `spotify-ripper <https://github.com/robbeofficial/spotifyripper>`__ that

--- a/README.rst
+++ b/README.rst
@@ -47,16 +47,10 @@ Command Line
 
 .. code::
 
-<<<<<<< HEAD
     usage: spotify-ripper [-h] [-S SETTINGS] [-a] [-A] [-b {160,320,96}] [-c]
                           [-d DIRECTORY] [-f] [-F] [-g {artist,album}] [-k KEY]
                           [-u USER] [-p PASSWORD] [-l] [-L LOG] [-m] [-o] [-s]
                           [-v VBR] [-V] [-r]
-=======
-    usage: spotify-ripper [-h] [-S SETTINGS] [-a] [-b {160,320,96}] [-c]
-                          [-d DIRECTORY] [-f] [-F] [-k KEY] [-u USER]
-                          [-p PASSWORD] [-l] [-m] [-o] [-s] [-v VBR] [-V] [-r]
->>>>>>> local-master
                           uri
 
     Rips Spotify URIs to MP3s with ID3 tags and album covers
@@ -68,13 +62,9 @@ Command Line
       -h, --help            show this help message and exit
       -S SETTINGS, --settings SETTINGS
                             Path to settings, config and temp files directory [Default=~/.spotify-ripper]
-<<<<<<< HEAD
       -a, --ascii           Convert the file name and the ID3 tag to ASCII encoding [Default=utf-8]
       -A, --ascii-path-only
                             Convert the file name (but not the ID3 tag) to ASCII encoding [Default=utf-8]
-=======
-      -a, --ascii           Convert file name to ASCII encoding [Default=utf-8]
->>>>>>> local-master
       -b {160,320,96}, --bitrate {160,320,96}
                             Bitrate rip quality [Default=320]
       -c, --cbr             Lame CBR encoding [Default=VBR]
@@ -82,20 +72,14 @@ Command Line
                             Base directory where ripped MP3s are saved [Default=cwd]
       -f, --flat            Save all songs to a single directory instead of organizing by album/artist/song
       -F, --Flat            Similar to --flat [-f] but includes the playlist index at the start of the song file
-<<<<<<< HEAD
       -g {artist,album}, --genres {artist,album}
                             Attempt to retrieve genre information from Spotify's Web API [Default=skip]
-=======
->>>>>>> local-master
       -k KEY, --key KEY     Path to Spotify application key file [Default=cwd]
       -u USER, --user USER  Spotify username
       -p PASSWORD, --password PASSWORD
                             Spotify password [Default=ask interactively]
       -l, --last            Use last login credentials
-<<<<<<< HEAD
       -L LOG, --log LOG     Log in a log-friendly format to a file (use - to log to stdout)
-=======
->>>>>>> local-master
       -m, --pcm             Saves a .pcm file with the raw PCM data
       -o, --overwrite       Overwrite existing MP3 files [Default=skip]
       -s, --strip-colors    Strip coloring from output[Default=colors]
@@ -107,10 +91,7 @@ Command Line
     Example usage:
         rip a single file: spotify-ripper -u user -p password spotify:track:52xaypL0Kjzk0ngwv3oBPR
         rip entire playlist: spotify-ripper -u user -p password spotify:user:username:playlist:4vkGNcsS8lRXj4q945NIA4
-<<<<<<< HEAD
         rip a list of URIs: spotify-ripper -u user -p password list_of_uris.txt
-=======
->>>>>>> local-master
         search for tracks to rip: spotify-ripper -l -b 160 -o "album:Rumours track:'the chain'"
 
 Config File

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
-spotify-ripper
-==============
+spotify-ripper |Version|
+========================
 
 A fork of
 `spotify-ripper <https://github.com/robbeofficial/spotifyripper>`__ that
@@ -181,3 +181,6 @@ License
 -------
 
 `MIT License <http://en.wikipedia.org/wiki/MIT_License>`__
+
+.. |Version| image:: http://img.shields.io/pypi/v/spotify-ripper.svg?style=flat-square
+  :target: https://pypi.python.org/pypi/spotify-ripper

--- a/README.rst
+++ b/README.rst
@@ -33,16 +33,23 @@ Features
 
 -  globally installs ripper script using pip
 
--  Python 2.7.x and 3.4.x compatible.  Python 3 will occasionally throw a ``NameError: name '_lock' is not defined`` exception at the end of the script due to an `upstream bug <https://github.com/mopidy/pyspotify/issues/133>`__ in pyspotify.
+-  Python 2.7.x and 3.4.x compatible.  Python 3 will occasionally throw a ``NameError: name '_lock' is not defined`` exception at the end of the script due to an `upstream bug <https://github.com/mopidy/pyspotify/issues/133>`__ in ``pyspotify``.
+
+-  use a config file to specify common command-line options
 
 Usage
 -----
 
+Command Line
+~~~~~~~~~~~~
+
+``spotify-ripper`` takes many command-line options
+
 .. code::
 
-    usage: spotify-ripper [-h] [-a] [-b {160,320,96}] [-c] [-d DIRECTORY] [-f]
-                          [-F] [-k KEY] [-u USER] [-p PASSWORD] [-l] [-m] [-o]
-                          [-s] [-S SETTINGS] [-v VBR] [-V] [-r]
+    usage: spotify-ripper [-h] [-S SETTINGS] [-a] [-b {160,320,96}] [-c]
+                          [-d DIRECTORY] [-f] [-F] [-k KEY] [-u USER]
+                          [-p PASSWORD] [-l] [-m] [-o] [-s] [-v VBR] [-V] [-r]
                           uri
 
     Rips Spotify URIs to MP3s with ID3 tags and album covers
@@ -52,6 +59,8 @@ Usage
 
     optional arguments:
       -h, --help            show this help message and exit
+      -S SETTINGS, --settings SETTINGS
+                            Path to settings, config and temp files directory [Default=~/.spotify-ripper]
       -a, --ascii           Convert file name to ASCII encoding [Default=utf-8]
       -b {160,320,96}, --bitrate {160,320,96}
                             Bitrate rip quality [Default=320]
@@ -68,8 +77,6 @@ Usage
       -m, --pcm             Saves a .pcm file with the raw PCM data
       -o, --overwrite       Overwrite existing MP3 files [Default=skip]
       -s, --strip-colors    Strip coloring from output[Default=colors]
-      -S SETTINGS, --settings SETTINGS
-                            Path to settings and temp files directory [Default=~/.spotify-ripper]
       -v VBR, --vbr VBR     Lame VBR encoding quality setting [Default=0]
       -V, --version         show program's version number and exit
       -r, --remove-from-playlist
@@ -79,6 +86,22 @@ Usage
         rip a single file: spotify-ripper -u user -p password spotify:track:52xaypL0Kjzk0ngwv3oBPR
         rip entire playlist: spotify-ripper -u user -p password spotify:user:username:playlist:4vkGNcsS8lRXj4q945NIA4
         search for tracks to rip: spotify-ripper -l -b 160 -o "album:Rumours track:'the chain'"
+
+Config File
+~~~~~~~~~~~
+
+For options that you want set on every run, you can use a config file named ``config.ini`` in the settings folder (defaults to ``~/.spotify-ripper``).  The options in the config file use the same name as the command line options with the exception that dashes are tranlated to ``snake_case``.  Any option specified in the command line will overwrite any setting in the config file.  Please put all options under a ``[main]`` section.
+
+Here is an example config file
+
+.. code:: ini
+
+    [main]
+    ascii = True
+    bitrate = 160
+    flat = True
+    last = True
+    remove_from_playlist = True
 
 Installation
 ------------

--- a/README.rst
+++ b/README.rst
@@ -108,13 +108,11 @@ Recommend approach uses `homebrew <http://brew.sh/>`__ and
 
 .. code:: bash
 
-    $ git clone https://github.com/jrnewell/spotify-ripper.git
-    $ cd spotify-ripper
     $ brew install homebrew/binary/libspotify
     $ sudo ln -s /usr/local/opt/libspotify/lib/libspotify.12.1.51.dylib \
         /usr/local/opt/libspotify/lib/libspotify
     $ brew install lame
-    $ pip install -e .
+    $ pip install spotify-ripper
     $ pyenv rehash
 
 Download an application key file ``spotify_appkey.key`` from
@@ -134,21 +132,27 @@ of libspotify.
 
 .. code:: bash
 
-    $ git clone https://github.com/jrnewell/spotify-ripper.git
-    $ cd spotify-ripper
     $ sudo apt-get install lame build-essential libffi-dev
     $ wget https://developer.spotify.com/download/libspotify/libspotify-12.1.51-Linux-x86_64-release.tar.gz # (assuming 64-bit)
     $ tar xvf libspotify-12.1.51-Linux-x86_64-release.tar.gz
     $ cd libspotify-12.1.51-Linux-x86_64-release/
     $ sudo make install prefix=/usr/local
-    $ cd ..
-    $ pip install -e .
+    $ pip install spotify-ripper
     $ pyenv rehash
 
 Download an application key file ``spotify_appkey.key`` from
 ``https://devaccount.spotify.com/my-account/keys/`` (requires a Spotify
 Premium Account) and move the file to the ``~/.spotify-ripper`` directory (or use
 the ``-k | --key`` option).
+
+Upgrade
+~~~~~~~
+
+Use ``pip`` to upgrade to the latest version.
+
+.. code:: bash
+
+    $ pip install --upgrade spotify-ripper
 
 License
 -------

--- a/default_config.ini
+++ b/default_config.ini
@@ -13,4 +13,4 @@ pcm = False
 overwrite = False
 strip_colors = False
 vbr = 0
-remove_from_playlist= False
+remove_from_playlist = False

--- a/default_config.ini
+++ b/default_config.ini
@@ -1,0 +1,16 @@
+[main]
+ascii = False
+bitrate = 320
+cbr = False
+directory = None
+flat = False
+Flat = False
+key = None
+user = None
+password = None
+last = False
+pcm = False
+overwrite = False
+strip_colors = False
+vbr = 0
+remove_from_playlist= False

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-pyspotify==2.0.0b4
+pyspotify==2.0.0b5
 colorama>=0.3.3
-mutagen==1.28
+mutagen==1.29
+requests>=2.3.0

--- a/setup.py
+++ b/setup.py
@@ -31,9 +31,9 @@ setup(
 
     # Requirements
     install_requires=[
-        'pyspotify==2.0.0b4',
+        'pyspotify==2.0.0b5',
         'colorama>=0.3.3',
-        'mutagen==1.28',
+        'mutagen==1.29',
         'requests>=2.3.0'
     ],
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def _read(fn):
 
 setup(
     name='spotify-ripper',
-    version='1.1.2',
+    version='1.1.3',
     packages=find_packages(exclude=["tests"]),
     scripts=['spotify_ripper/main.py'],
     include_package_data=True,
@@ -42,7 +42,7 @@ setup(
     license='MIT',
     keywords="spotify ripper mp3",
     url='https://github.com/jrnewell/spotify-ripper',
-    download_url = 'https://github.com/jrnewell/spotify-ripper/tarball/1.1.2',
+    download_url = 'https://github.com/jrnewell/spotify-ripper/tarball/1.1.3',
     classifiers=[
         'Topic :: Multimedia :: Sound/Audio',
         'Topic :: Multimedia :: Sound/Audio :: Capture/Recording',

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def _read(fn):
 
 setup(
     name='spotify-ripper',
-    version='1.1.0',
+    version='1.1.1',
     packages=find_packages(exclude=["tests"]),
     scripts=['spotify_ripper/main.py'],
     include_package_data=True,
@@ -42,7 +42,7 @@ setup(
     license='MIT',
     keywords="spotify ripper mp3",
     url='https://github.com/jrnewell/spotify-ripper',
-    download_url = 'https://github.com/jrnewell/spotify-ripper/tarball/1.1.0',
+    download_url = 'https://github.com/jrnewell/spotify-ripper/tarball/1.1.1',
     classifiers=[
         'Topic :: Multimedia :: Sound/Audio',
         'Topic :: Multimedia :: Sound/Audio :: Capture/Recording',

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def _read(fn):
 
 setup(
     name='spotify-ripper',
-    version='1.1.1',
+    version='1.1.2',
     packages=find_packages(exclude=["tests"]),
     scripts=['spotify_ripper/main.py'],
     include_package_data=True,
@@ -42,7 +42,7 @@ setup(
     license='MIT',
     keywords="spotify ripper mp3",
     url='https://github.com/jrnewell/spotify-ripper',
-    download_url = 'https://github.com/jrnewell/spotify-ripper/tarball/1.1.1',
+    download_url = 'https://github.com/jrnewell/spotify-ripper/tarball/1.1.2',
     classifiers=[
         'Topic :: Multimedia :: Sound/Audio',
         'Topic :: Multimedia :: Sound/Audio :: Capture/Recording',

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
 
     # Metadata
     author='James Newell',
+    author_email='james.newell@gmail.com',
     description='a small ripper for Spotify that rips Spotify URIs to MP3 files',
     license='MIT',
     keywords="spotify ripper mp3",

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
     license='MIT',
     keywords="spotify ripper mp3",
     url='https://github.com/jrnewell/spotify-ripper',
+    download_url = 'https://github.com/jrnewell/spotify-ripper/tarball/1.1.0',
     classifiers=[
         'Topic :: Multimedia :: Sound/Audio',
         'Topic :: Multimedia :: Sound/Audio :: Capture/Recording',

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def _read(fn):
 
 setup(
     name='spotify-ripper',
-    version='1.0.0',
+    version='1.0.1',
     packages=find_packages(exclude=["tests"]),
     scripts=['spotify_ripper/ripper.py'],
     include_package_data=True,

--- a/spotify_ripper/id3.py
+++ b/spotify_ripper/id3.py
@@ -72,8 +72,7 @@ def set_id3_and_cover(args, mp3_file, track):
         audio = mp3.MP3(mp3_file, ID3=id3.ID3)
         on_error = 'replace' if args.ascii_path_only else 'ignore'
         album = to_ascii(args, track.album.name, on_error)
-        artist = to_ascii(args, track.artists[0].name, on_error)
-        artists = to_ascii(args, ', '.join(tas.name for tas in track.artists), on_error)
+        artist = to_ascii(args, ', '.join(tas.name for tas in track.artists), on_error)
         title = to_ascii(args, track.name, on_error)
         if genres is not None and genres:
             genres_ascii = [to_ascii(args, genre) for genre in genres]
@@ -113,7 +112,7 @@ def set_id3_and_cover(args, mp3_file, track):
 
         if album is not None: audio.tags.add(id3.TALB(text=[id3_to_ascii(track.album.name, album)], encoding=3))
         audio.tags.add(id3.TIT2(text=[id3_to_ascii(track.name, title)], encoding=3))
-        audio.tags.add(id3.TPE1(text=[id3_to_ascii(', '.join(tas.name for tas in track.artists), artists)], encoding=3))
+        audio.tags.add(id3.TPE1(text=[id3_to_ascii(', '.join(tas.name for tas in track.artists), artist)], encoding=3))
         audio.tags.add(id3.TDRC(text=[str(track.album.year)], encoding=3))
         audio.tags.add(id3.TDRL(text=[str(track.album.year)], encoding=3))
         audio.tags.add(id3.TPOS(text=[idx_of_total_str(track.disc, num_discs)], encoding=3))

--- a/spotify_ripper/id3.py
+++ b/spotify_ripper/id3.py
@@ -100,7 +100,6 @@ def set_id3_and_cover(args, mp3_file, track):
                 )
             )
 
-
         def id3_to_ascii(_str, _str_ascii):
             return _str if args.ascii_path_only else _str_ascii
 
@@ -123,10 +122,10 @@ def set_id3_and_cover(args, mp3_file, track):
             audio.tags.add(tcon_tag)
 
         def bit_rate_str(bit_rate):
-           brs = "%d kb/s" % bit_rate
-           if not args.cbr:
-              brs = "~" + brs
-           return brs
+            brs = "%d kb/s" % bit_rate
+            if not args.cbr:
+                brs = "~" + brs
+            return brs
 
         def mode_str(mode):
             modes = ["Stereo", "Joint Stereo", "Dual Channel", "Mono"]
@@ -135,19 +134,21 @@ def set_id3_and_cover(args, mp3_file, track):
             else:
                 return ""
 
-        print(Fore.GREEN + Style.BRIGHT + os.path.basename(mp3_file) + Style.NORMAL + "\t[ " + format_size(os.stat(mp3_file)[ST_SIZE]) + " ]" + Fore.RESET)
+        print(Fore.GREEN + Style.BRIGHT + os.path.basename(mp3_file) + Style.NORMAL + "\t[ " + format_size(
+            os.stat(mp3_file)[ST_SIZE]) + " ]" + Fore.RESET)
         print("-" * 79)
         print(Fore.YELLOW + "Setting artist: " + artist + Fore.RESET)
         if album is not None: print(Fore.YELLOW + "Setting album: " + album + Fore.RESET)
         print(Fore.YELLOW + "Setting title: " + title + Fore.RESET)
-        print(Fore.YELLOW + "Setting track info: (" + str(track.index) + ", " + str(num_tracks) + ")"  + Fore.RESET)
-        print(Fore.YELLOW + "Setting disc info: (" + str(track.disc) + ", " + str(num_discs) + ")"  + Fore.RESET)
+        print(Fore.YELLOW + "Setting track info: (" + str(track.index) + ", " + str(num_tracks) + ")" + Fore.RESET)
+        print(Fore.YELLOW + "Setting disc info: (" + str(track.disc) + ", " + str(num_discs) + ")" + Fore.RESET)
         print(Fore.YELLOW + "Setting release year: " + str(track.album.year) + Fore.RESET)
-        if genres is not None and genres: print(Fore.YELLOW + "Setting genres: " + " / ".join(genres_ascii) + Fore.RESET)
+        if genres is not None and genres: print(
+            Fore.YELLOW + "Setting genres: " + " / ".join(genres_ascii) + Fore.RESET)
         if image is not None: print(Fore.YELLOW + "Adding image cover.jpg" + Fore.RESET)
         print("Time: " + format_time(audio.info.length) + "\tMPEG" + str(audio.info.version) +
-            ", Layer " + ("I" * audio.info.layer) + "\t[ " + bit_rate_str(audio.info.bitrate / 1000) +
-            " @ " + str(audio.info.sample_rate) + " Hz - " + mode_str(audio.info.mode) + " ]")
+              ", Layer " + ("I" * audio.info.layer) + "\t[ " + bit_rate_str(audio.info.bitrate / 1000) +
+              " @ " + str(audio.info.sample_rate) + " Hz - " + mode_str(audio.info.mode) + " ]")
         print("-" * 79)
         id3_version = "v%d.%d" % (audio.tags.version[0], audio.tags.version[1])
         print("ID3 " + id3_version + ": " + str(len(audio.tags.values())) + " frames")

--- a/spotify_ripper/id3.py
+++ b/spotify_ripper/id3.py
@@ -113,6 +113,7 @@ def set_id3_and_cover(args, mp3_file, track):
         if album is not None: audio.tags.add(id3.TALB(text=[id3_to_ascii(track.album.name, album)], encoding=3))
         audio.tags.add(id3.TIT2(text=[id3_to_ascii(track.name, title)], encoding=3))
         audio.tags.add(id3.TPE1(text=[id3_to_ascii(track.artists[0].name, artist)], encoding=3))
+        audio.tags.add(id3.TDRC(text=[str(track.album.year)], encoding=3))
         audio.tags.add(id3.TDRL(text=[str(track.album.year)], encoding=3))
         audio.tags.add(id3.TPOS(text=[idx_of_total_str(track.disc, num_discs)], encoding=3))
         audio.tags.add(id3.TRCK(text=[idx_of_total_str(track.index, num_tracks)], encoding=3))

--- a/spotify_ripper/id3.py
+++ b/spotify_ripper/id3.py
@@ -73,6 +73,7 @@ def set_id3_and_cover(args, mp3_file, track):
         on_error = 'replace' if args.ascii_path_only else 'ignore'
         album = to_ascii(args, track.album.name, on_error)
         artist = to_ascii(args, track.artists[0].name, on_error)
+        artists = to_ascii(args, ', '.join(tas.name for tas in track.artists), on_error)
         title = to_ascii(args, track.name, on_error)
         if genres is not None and genres:
             genres_ascii = [to_ascii(args, genre) for genre in genres]
@@ -112,7 +113,7 @@ def set_id3_and_cover(args, mp3_file, track):
 
         if album is not None: audio.tags.add(id3.TALB(text=[id3_to_ascii(track.album.name, album)], encoding=3))
         audio.tags.add(id3.TIT2(text=[id3_to_ascii(track.name, title)], encoding=3))
-        audio.tags.add(id3.TPE1(text=[id3_to_ascii(track.artists[0].name, artist)], encoding=3))
+        audio.tags.add(id3.TPE1(text=[id3_to_ascii(', '.join(tas.name for tas in track.artists), artists)], encoding=3))
         audio.tags.add(id3.TDRC(text=[str(track.album.year)], encoding=3))
         audio.tags.add(id3.TDRL(text=[str(track.album.year)], encoding=3))
         audio.tags.add(id3.TPOS(text=[idx_of_total_str(track.disc, num_discs)], encoding=3))

--- a/spotify_ripper/id3.py
+++ b/spotify_ripper/id3.py
@@ -2,7 +2,6 @@
 
 from __future__ import unicode_literals
 
-from subprocess import call
 from colorama import Fore, Style
 from mutagen import mp3, id3
 from stat import ST_SIZE
@@ -96,4 +95,4 @@ def set_id3_and_cover(args, mp3_file, track):
         print(Fore.YELLOW + "Warning: exception while saving id3 tag: " + str(id3.error) + Fore.RESET)
 
     # delete cover
-    if image is not None: call(["rm", "-f", "cover.jpg"])
+    if image is not None: rm_file("cover.jpg")

--- a/spotify_ripper/id3.py
+++ b/spotify_ripper/id3.py
@@ -27,6 +27,9 @@ def set_id3_and_cover(args, mp3_file, track):
     # use mutagen to update id3v2 tags
     try:
         audio = mp3.MP3(mp3_file, ID3=id3.ID3)
+        album = to_ascii(args, track.album.name)
+        artist = to_ascii(args, track.artists[0].name)
+        title = to_ascii(args, track.name)
 
         # add ID3 tag if it doesn't exist
         audio.add_tags()
@@ -51,12 +54,18 @@ def set_id3_and_cover(args, mp3_file, track):
                 )
             )
 
-        audio.tags.add(id3.TALB(text=[track.album.name], encoding=3))
-        audio.tags.add(id3.TIT2(text=[track.name], encoding=3))
-        audio.tags.add(id3.TPE1(text=[track.artists[0].name], encoding=3))
+        def idx_of_total_str(_idx, _total):
+            if _total > 0:
+                return "%d/%d" % (_idx, _total)
+            else:
+                return "%d" % (_idx)
+
+        if album is not None: audio.tags.add(id3.TALB(text=[album], encoding=3))
+        audio.tags.add(id3.TIT2(text=[title], encoding=3))
+        audio.tags.add(id3.TPE1(text=[artist], encoding=3))
         audio.tags.add(id3.TDRL(text=[str(track.album.year)], encoding=3))
-        audio.tags.add(id3.TPOS(text=[("%d/%d" % (track.disc, num_discs))], encoding=3))
-        audio.tags.add(id3.TRCK(text=[("%d/%d" % (track.index, num_tracks))], encoding=3))
+        audio.tags.add(id3.TPOS(text=[idx_of_total_str(track.disc, num_discs)], encoding=3))
+        audio.tags.add(id3.TRCK(text=[idx_of_total_str(track.index, num_tracks)], encoding=3))
 
         def bit_rate_str(bit_rate):
            brs = "%d kb/s" % bit_rate
@@ -73,9 +82,9 @@ def set_id3_and_cover(args, mp3_file, track):
 
         print(Fore.GREEN + Style.BRIGHT + os.path.basename(mp3_file) + Style.NORMAL + "\t[ " + format_size(os.stat(mp3_file)[ST_SIZE]) + " ]" + Fore.RESET)
         print("-" * 79)
-        print(Fore.YELLOW + "Setting artist: " + track.artists[0].name + Fore.RESET)
-        print(Fore.YELLOW + "Setting album: " + track.album.name + Fore.RESET)
-        print(Fore.YELLOW + "Setting title: " + track.name + Fore.RESET)
+        print(Fore.YELLOW + "Setting artist: " + artist + Fore.RESET)
+        if album is not None: print(Fore.YELLOW + "Setting album: " + album + Fore.RESET)
+        print(Fore.YELLOW + "Setting title: " + title + Fore.RESET)
         print(Fore.YELLOW + "Setting track info: (" + str(track.index) + ", " + str(num_tracks) + ")"  + Fore.RESET)
         print(Fore.YELLOW + "Setting disc info: (" + str(track.disc) + ", " + str(num_discs) + ")"  + Fore.RESET)
         print(Fore.YELLOW + "Setting release year: " + str(track.album.year) + Fore.RESET)

--- a/spotify_ripper/id3.py
+++ b/spotify_ripper/id3.py
@@ -96,4 +96,4 @@ def set_id3_and_cover(args, mp3_file, track):
         print(Fore.YELLOW + "Warning: exception while saving id3 tag: " + str(id3.error) + Fore.RESET)
 
     # delete cover
-    call(["rm", "-f", "cover.jpg"])
+    if image is not None: call(["rm", "-f", "cover.jpg"])

--- a/spotify_ripper/main.py
+++ b/spotify_ripper/main.py
@@ -10,7 +10,7 @@ import os, sys
 import time
 import argparse
 import pkg_resources
-import ConfigParser
+import configparser
 
 
 def load_config(args, defaults):
@@ -18,7 +18,8 @@ def load_config(args, defaults):
     config_file = os.path.join(settings_dir, "config.ini")
     if os.path.exists(config_file):
         try:
-            config = ConfigParser.SafeConfigParser()
+            # module ConfigParser unknown in Python3
+            config = configparser.ConfigParser()
 
             config.read(config_file)
             if not config.has_section("main"): return defaults
@@ -39,7 +40,7 @@ def load_config(args, defaults):
 
             # overwrite any existing defaults
             defaults.update(config_items)
-        except (ConfigParser.Error) as e:
+        except (configparser.Error) as e:
             print("\nError parsing config file: " + config_file)
             print(str(e))
 
@@ -102,6 +103,8 @@ def main():
     parser.add_argument('-L', '--log', nargs=1, help='Log in a log-friendly format to a file (use - to log to stdout)')
     parser.add_argument('-m', '--pcm', action='store_true', help='Saves a .pcm file with the raw PCM data')
     parser.add_argument('-o', '--overwrite', action='store_true', help='Overwrite existing MP3 files [Default=skip]')
+    parser.add_argument('-P', '--playlist', action='store_true',
+                        help='Store playlist in separate directories and keep track of changes')
     parser.add_argument('-s', '--strip-colors', action='store_true', help='Strip coloring from output[Default=colors]')
     parser.add_argument('-v', '--vbr', help='Lame VBR encoding quality setting [Default=0]')
     parser.add_argument('-V', '--version', action='version', version=pkg_resources.require("spotify-ripper")[0].version)

--- a/spotify_ripper/main.py
+++ b/spotify_ripper/main.py
@@ -30,9 +30,12 @@ def load_config(args, defaults):
             # coerce boolean and none types
             for _key in config_items:
                 item = config_items[_key]
-                if item == 'True': config_items[_key] = True
-                elif item == 'False': config_items[_key] = False
-                elif item == 'None': config_items[_key] = None
+                if item == 'True':
+                    config_items[_key] = True
+                elif item == 'False':
+                    config_items[_key] = False
+                elif item == 'None':
+                    config_items[_key] = None
 
                 # certain options need to be in array (nargs=1)
                 if _key in to_array_options:
@@ -48,10 +51,11 @@ def load_config(args, defaults):
 
 
 def main():
-    # in case we changed the location of the settings directory where the config file lives, we need to parse this argument
-    # before we parse the rest of the arguments (which can overwrite the options in the config file)
+    # in case we changed the location of the settings directory where the config file lives, we need to parse this
+    # argument before we parse the rest of the arguments (which can overwrite the options in the config file)
     settings_parser = argparse.ArgumentParser(add_help=False)
-    settings_parser.add_argument('-S', '--settings', nargs=1, help='Path to settings, config and temp files directory [Default=~/.spotify-ripper]')
+    settings_parser.add_argument('-S', '--settings', nargs=1,
+                                 help='Path to settings, config and temp files directory [Default=~/.spotify-ripper]')
     args, remaining_argv = settings_parser.parse_known_args()
 
     # load config file, overwriting any defaults
@@ -61,10 +65,11 @@ def main():
     }
     defaults = load_config(args, defaults)
 
-    parser = argparse.ArgumentParser(prog='spotify-ripper', description='Rips Spotify URIs to MP3s with ID3 tags and album covers',
-        parents=[settings_parser],
-        formatter_class=argparse.RawTextHelpFormatter,
-        epilog='''Example usage:
+    parser = argparse.ArgumentParser(prog='spotify-ripper',
+                                     description='Rips Spotify URIs to MP3s with ID3 tags and album covers',
+                                     parents=[settings_parser],
+                                     formatter_class=argparse.RawTextHelpFormatter,
+                                     epilog='''Example usage:
     rip a single file: spotify-ripper -u user -p password spotify:track:52xaypL0Kjzk0ngwv3oBPR
     rip entire playlist: spotify-ripper -u user -p password spotify:user:username:playlist:4vkGNcsS8lRXj4q945NIA4
     rip a list of URIs: spotify-ripper -u user -p password list_of_uris.txt
@@ -87,15 +92,19 @@ def main():
     # set defaults
     parser.set_defaults(**defaults)
 
-
-    parser.add_argument('-a', '--ascii', action='store_true', help='Convert the file name and the ID3 tag to ASCII encoding [Default=utf-8]')
-    parser.add_argument('-A', '--ascii-path-only', action='store_true', help='Convert the file name (but not the ID3 tag) to ASCII encoding [Default=utf-8]')
+    parser.add_argument('-a', '--ascii', action='store_true',
+                        help='Convert the file name and the ID3 tag to ASCII encoding [Default=utf-8]')
+    parser.add_argument('-A', '--ascii-path-only', action='store_true',
+                        help='Convert the file name (but not the ID3 tag) to ASCII encoding [Default=utf-8]')
     parser.add_argument('-b', '--bitrate', choices=['160', '320', '96'], help='Bitrate rip quality [Default=320]')
     parser.add_argument('-c', '--cbr', action='store_true', help='Lame CBR encoding [Default=VBR]')
     parser.add_argument('-d', '--directory', nargs=1, help='Base directory where ripped MP3s are saved [Default=cwd]')
-    parser.add_argument('-f', '--flat', action='store_true', help='Save all songs to a single directory instead of organizing by album/artist/song')
-    parser.add_argument('-F', '--Flat', action='store_true', help='Similar to --flat [-f] but includes the playlist index at the start of the song file')
-    parser.add_argument('-g', '--genres', nargs=1, choices=['artist', 'album'], help='Attempt to retrieve genre information from Spotify\'s Web API [Default=skip]')
+    parser.add_argument('-f', '--flat', action='store_true',
+                        help='Save all songs to a single directory instead of organizing by album/artist/song')
+    parser.add_argument('-F', '--Flat', action='store_true',
+                        help='Similar to --flat [-f] but includes the playlist index at the start of the song file')
+    parser.add_argument('-g', '--genres', nargs=1, choices=['artist', 'album'],
+                        help='Attempt to retrieve genre information from Spotify\'s Web API [Default=skip]')
     parser.add_argument('-k', '--key', nargs=1, help='Path to Spotify application key file [Default=cwd]')
     group.add_argument('-u', '--user', nargs=1, help='Spotify username')
     parser.add_argument('-p', '--password', nargs=1, help='Spotify password [Default=ask interactively]')
@@ -108,7 +117,8 @@ def main():
     parser.add_argument('-s', '--strip-colors', action='store_true', help='Strip coloring from output[Default=colors]')
     parser.add_argument('-v', '--vbr', help='Lame VBR encoding quality setting [Default=0]')
     parser.add_argument('-V', '--version', action='version', version=pkg_resources.require("spotify-ripper")[0].version)
-    parser.add_argument('-r', '--remove-from-playlist', action='store_true', help='Delete tracks from playlist after successful ripping [Default=no]')
+    parser.add_argument('-r', '--remove-from-playlist', action='store_true',
+                        help='Delete tracks from playlist after successful ripping [Default=no]')
     parser.add_argument('uri', help='Spotify URI (either URI, a file of URIs or a search query)')
     args = parser.parse_args(remaining_argv)
 
@@ -117,7 +127,7 @@ def main():
     def wrap_stream(stream, convert, strip, autoreset, wrap):
         if wrap:
             wrapper = AnsiToWin32(stream,
-                convert=convert, strip=strip, autoreset=autoreset)
+                                  convert=convert, strip=strip, autoreset=autoreset)
             if wrapper.should_wrap():
                 stream = wrapper.stream
         return stream
@@ -147,6 +157,7 @@ def main():
         print("\n" + Fore.RED + "Aborting..." + Fore.RESET)
         ripper.abort()
         sys.exit(1)
+
 
 if __name__ == '__main__':
     main()

--- a/spotify_ripper/main.py
+++ b/spotify_ripper/main.py
@@ -116,7 +116,8 @@ def main():
                         help='Store playlist in separate directories and keep track of changes')
     parser.add_argument('-s', '--strip-colors', action='store_true', help='Strip coloring from output[Default=colors]')
     parser.add_argument('-v', '--vbr', help='Lame VBR encoding quality setting [Default=0]')
-    parser.add_argument('-V', '--version', action='version', version=pkg_resources.require("spotify-ripper")[0].version)
+    parser.add_argument('-V', '--version', action='version', version="dev" )
+                        #version=pkg_resources.require("spotify-ripper")[0].version)
     parser.add_argument('-r', '--remove-from-playlist', action='store_true',
                         help='Delete tracks from playlist after successful ripping [Default=no]')
     parser.add_argument('uri', help='Spotify URI (either URI, a file of URIs or a search query)')

--- a/spotify_ripper/main.py
+++ b/spotify_ripper/main.py
@@ -14,7 +14,7 @@ import pkg_resources
 import ConfigParser
 
 def load_config(args, defaults):
-    settings_dir = args.settings[0] if args.settings is not None else norm_path(os.path.join(os.path.expanduser("~"), ".spotify-ripper"))
+    settings_dir = args.settings[0] if args.settings is not None else default_settings_dir()
     config_file = os.path.join(settings_dir, "config.ini")
     if os.path.exists(config_file):
         try:
@@ -33,7 +33,7 @@ def load_config(args, defaults):
             # overwrite any existing defaults
             defaults.update(config_items)
         except (ConfigParser.Error) as e:
-            print("\nError parsing config: " + config_file)
+            print("\nError parsing config file: " + config_file)
             print(str(e))
 
     return defaults
@@ -42,8 +42,8 @@ def main():
     logging.basicConfig(level=logging.INFO)
     logger = logging.getLogger('spotify.ripper')
 
-    # in case we changed the location of the settings directory where the config file lives, we need to parse argument
-    # first before we parse the rest of the arguments
+    # in case we changed the location of the settings directory where the config file lives, we need to parse this argument
+    # before we parse the rest of the arguments (which can overwrite the options in the config file)
     settings_parser = argparse.ArgumentParser(add_help=False)
     settings_parser.add_argument('-S', '--settings', nargs=1, help='Path to settings, config and temp files directory [Default=~/.spotify-ripper]')
     args, remaining_argv = settings_parser.parse_known_args()
@@ -65,8 +65,10 @@ def main():
     ''')
 
     # create group to prevent to prevent user from using both the -l and -u option
-    if defaults.get('user') is not None or defaults.get('last') is True:
-        if defaults.get('user') is not None and defaults.get('last') is True:
+    is_user_set = defaults.get('user') is not None
+    is_last_set = defaults.get('last') is True
+    if is_user_set or is_last_set:
+        if is_user_set and is_last_set:
             print("spotify-ripper: error: one of the arguments -u/--user -l/--last is required")
             sys.exit(1)
         else:

--- a/spotify_ripper/main.py
+++ b/spotify_ripper/main.py
@@ -5,17 +5,58 @@ from __future__ import unicode_literals
 
 from colorama import init, Fore, Style
 from spotify_ripper.ripper import Ripper
+from spotify_ripper.utils import *
 import os, sys
 import time
 import logging
 import argparse
 import pkg_resources
+import ConfigParser
+
+def load_config(args, defaults):
+    settings_dir = args.settings[0] if args.settings is not None else norm_path(os.path.join(os.path.expanduser("~"), ".spotify-ripper"))
+    config_file = os.path.join(settings_dir, "config.ini")
+    if os.path.exists(config_file):
+        try:
+            config = ConfigParser.SafeConfigParser()
+            config.read(config_file)
+            if not config.has_section("main"): return defaults
+            config_items = dict(config.items("main"))
+
+            # coerce boolean and none types
+            for _key in config_items:
+                item = config_items[_key]
+                if item == 'True': config_items[_key] = True
+                elif item == 'False': config_items[_key] = False
+                elif item == 'None': config_items[_key] = None
+
+            # overwrite any existing defaults
+            defaults.update(config_items)
+        except (ConfigParser.Error) as e:
+            print("\nError parsing config: " + config_file)
+            print(str(e))
+
+    return defaults
 
 def main():
     logging.basicConfig(level=logging.INFO)
     logger = logging.getLogger('spotify.ripper')
 
+    # in case we changed the location of the settings directory where the config file lives, we need to parse argument
+    # first before we parse the rest of the arguments
+    settings_parser = argparse.ArgumentParser(add_help=False)
+    settings_parser.add_argument('-S', '--settings', nargs=1, help='Path to settings, config and temp files directory [Default=~/.spotify-ripper]')
+    args, remaining_argv = settings_parser.parse_known_args()
+
+    # load config file, overwriting any defaults
+    defaults = {
+        "bitrate": "320",
+        "vbr": "0",
+    }
+    defaults = load_config(args, defaults)
+
     parser = argparse.ArgumentParser(prog='spotify-ripper', description='Rips Spotify URIs to MP3s with ID3 tags and album covers',
+        parents=[settings_parser],
         formatter_class=argparse.RawTextHelpFormatter,
         epilog='''Example usage:
     rip a single file: spotify-ripper -u user -p password spotify:track:52xaypL0Kjzk0ngwv3oBPR
@@ -23,10 +64,21 @@ def main():
     search for tracks to rip: spotify-ripper -l -b 160 -o "album:Rumours track:'the chain'"
     ''')
 
-    group = parser.add_mutually_exclusive_group(required=True)
+    # create group to prevent to prevent user from using both the -l and -u option
+    if defaults.get('user') is not None or defaults.get('last') is True:
+        if defaults.get('user') is not None and defaults.get('last') is True:
+            print("spotify-ripper: error: one of the arguments -u/--user -l/--last is required")
+            sys.exit(1)
+        else:
+            group = parser.add_mutually_exclusive_group(required=False)
+    else:
+        group = parser.add_mutually_exclusive_group(required=True)
+
+    # set defaults
+    parser.set_defaults(**defaults)
 
     parser.add_argument('-a', '--ascii', action='store_true', help='Convert file name to ASCII encoding [Default=utf-8]')
-    parser.add_argument('-b', '--bitrate', default='320', choices=['160', '320', '96'], help='Bitrate rip quality [Default=320]')
+    parser.add_argument('-b', '--bitrate', choices=['160', '320', '96'], help='Bitrate rip quality [Default=320]')
     parser.add_argument('-c', '--cbr', action='store_true', help='Lame CBR encoding [Default=VBR]')
     parser.add_argument('-d', '--directory', nargs=1, help='Base directory where ripped MP3s are saved [Default=cwd]')
     parser.add_argument('-f', '--flat', action='store_true', help='Save all songs to a single directory instead of organizing by album/artist/song')
@@ -38,12 +90,11 @@ def main():
     parser.add_argument('-m', '--pcm', action='store_true', help='Saves a .pcm file with the raw PCM data')
     parser.add_argument('-o', '--overwrite', action='store_true', help='Overwrite existing MP3 files [Default=skip]')
     parser.add_argument('-s', '--strip-colors', action='store_true', help='Strip coloring from output[Default=colors]')
-    parser.add_argument('-S', '--settings', nargs=1, help='Path to settings and temp files directory [Default=~/.spotify-ripper]')
-    parser.add_argument('-v', '--vbr', default='0', help='Lame VBR encoding quality setting [Default=0]')
+    parser.add_argument('-v', '--vbr', help='Lame VBR encoding quality setting [Default=0]')
     parser.add_argument('-V', '--version', action='version', version=pkg_resources.require("spotify-ripper")[0].version)
     parser.add_argument('-r', '--remove-from-playlist', action='store_true', help='Delete tracks from playlist after successful ripping [Default=no]')
     parser.add_argument('uri', help='Spotify URI (either URI, a file of URIs or a search query)')
-    args = parser.parse_args()
+    args = parser.parse_args(remaining_argv)
 
     init(strip=True if args.strip_colors else None)
 

--- a/spotify_ripper/ripper.py
+++ b/spotify_ripper/ripper.py
@@ -16,10 +16,12 @@ import spotify
 import getpass
 import itertools
 
+
 class BitRate(spotify.utils.IntEnum):
     BITRATE_160K = 0
     BITRATE_320K = 1
-    BITRATE_96K  = 2
+    BITRATE_96K = 2
+
 
 class Ripper(threading.Thread):
     mp3_file = None
@@ -32,6 +34,7 @@ class Ripper(threading.Thread):
     base_dir = None
     duration = None
     position = 0
+    idx_digits = 2
     tracks_to_remove = []
     end_of_track = threading.Event()
 
@@ -60,7 +63,7 @@ class Ripper(threading.Thread):
             app_key_path = os.path.join(default_dir, "spotify_appkey.key")
             if not os.path.exists(app_key_path):
                 print("\n" + Fore.YELLOW + "Please copy your spotify_appkey.key to " + default_dir +
-                    ", or use the --key|-k option" + Fore.RESET)
+                      ", or use the --key|-k option" + Fore.RESET)
 
                 sys.exit(1)
 
@@ -83,13 +86,13 @@ class Ripper(threading.Thread):
             ('96', BitRate.BITRATE_96K)])
         self.session.preferred_bitrate(bit_rates[args.bitrate])
         self.session.on(spotify.SessionEvent.CONNECTION_STATE_UPDATED,
-            self.on_connection_state_changed)
+                        self.on_connection_state_changed)
         self.session.on(spotify.SessionEvent.END_OF_TRACK,
-            self.on_end_of_track)
+                        self.on_end_of_track)
         self.session.on(spotify.SessionEvent.MUSIC_DELIVERY,
-            self.on_music_delivery)
+                        self.on_music_delivery)
         self.session.on(spotify.SessionEvent.PLAY_TOKEN_LOST,
-            self.play_token_lost)
+                        self.play_token_lost)
 
         self.event_loop = spotify.EventLoop(self.session)
         self.event_loop.start()
@@ -170,11 +173,11 @@ class Ripper(threading.Thread):
                             self.tracks_to_remove.append(idx)
                         else:
                             print(Fore.RED + "This track will not be removed from playlist " +
-                                self.current_playlist.name + " since " + self.session.user.canonical_name +
-                                " is not the playlist owner..." + Fore.RESET)
+                                  self.current_playlist.name + " since " + self.session.user.canonical_name +
+                                  " is not the playlist owner..." + Fore.RESET)
                     else:
                         print(Fore.RED + "No playlist specified to remove this track from. " +
-                                "Did you use '-r' without a playlist link?" + Fore.RESET)
+                              "Did you use '-r' without a playlist link?" + Fore.RESET)
 
             except spotify.Error as e:
                 print(Fore.RED + "Spotify error detected" + Fore.RESET)
@@ -183,7 +186,6 @@ class Ripper(threading.Thread):
                 self.session.player.play(False)
                 self.clean_up_partial()
                 continue
-
 
         song_library.update_library()
 
@@ -245,7 +247,9 @@ class Ripper(threading.Thread):
         # list tracks
         print(Fore.GREEN + "Results" + Fore.RESET)
         for track_idx, track in enumerate(result.tracks):
-            print("  " + Fore.YELLOW + str(track_idx + 1) + Fore.RESET + " [" + to_ascii(args, track.album.name) + "] " + to_ascii(args, track.artists[0].name) + " - " + to_ascii(args, track.name) + " (" + str(track.popularity) + ")")
+            print("  " + Fore.YELLOW + str(track_idx + 1) + Fore.RESET + " [" + to_ascii(args,
+                                                                                         track.album.name) + "] " + to_ascii(
+                args, track.artists[0].name) + " - " + to_ascii(args, track.name) + " (" + str(track.popularity) + ")")
 
         pick = raw_input("Pick track(s) (ex 1-3,5): ")
 
@@ -264,7 +268,8 @@ class Ripper(threading.Thread):
             def range_string(comma_string):
                 def hyphen_range(hyphen_string):
                     x = [int(x) - 1 for x in hyphen_string.split('-')]
-                    return range(x[0], x[-1]+1)
+                    return range(x[0], x[-1] + 1)
+
                 return itertools.chain(*[hyphen_range(r) for r in comma_string.split(',')])
 
             picks = sorted(set(list(range_string(pick))))
@@ -292,7 +297,7 @@ class Ripper(threading.Thread):
             self.logged_out.set()
 
     def play_token_lost(self, session):
-        print("\n"  + Fore.RED + "Play token lost, aborting..." + Fore.RESET)
+        print("\n" + Fore.RED + "Play token lost, aborting..." + Fore.RESET)
         self.session.player.play(False)
         self.clean_up_partial()
         self.finished = True
@@ -334,7 +339,7 @@ class Ripper(threading.Thread):
             self.rip_proc = Popen(["lame", "--silent", "-V", args.vbr, "-h", "-r", "-", self.mp3_file], stdin=PIPE)
         self.pipe = self.rip_proc.stdin
         if args.pcm:
-          self.pcm_file = open(self.mp3_file[:-4] + ".pcm", 'w')
+            self.pcm_file = open(self.mp3_file[:-4] + ".pcm", 'w')
 
         self.ripping = True
 
@@ -375,7 +380,7 @@ class Ripper(threading.Thread):
             self.update_progress()
             self.pipe.write(frame_bytes);
             if self.args.pcm:
-              self.pcm_file.write(frame_bytes)
+                self.pcm_file.write(frame_bytes)
 
 
     def abort(self):

--- a/spotify_ripper/ripper.py
+++ b/spotify_ripper/ripper.py
@@ -2,7 +2,7 @@
 
 from __future__ import unicode_literals
 
-from subprocess import call, Popen, PIPE
+from subprocess import Popen, PIPE
 from colorama import Fore, Style
 from spotify_ripper.utils import *
 from spotify_ripper.id3 import set_id3_and_cover
@@ -257,7 +257,7 @@ class Ripper(threading.Thread):
     def clean_up_partial(self):
         if os.path.exists(self.mp3_file):
             print(Fore.YELLOW + "Deleting partially ripped file" + Fore.RESET)
-            call(["rm", "-f", self.mp3_file])
+            rm_file(self.mp3_file)
 
     def on_music_delivery(self, session, audio_format, frame_bytes, num_frames):
         self.rip(session, audio_format, frame_bytes, num_frames)

--- a/spotify_ripper/ripper.py
+++ b/spotify_ripper/ripper.py
@@ -85,6 +85,8 @@ class Ripper(threading.Thread):
             self.on_end_of_track)
         self.session.on(spotify.SessionEvent.MUSIC_DELIVERY,
             self.on_music_delivery)
+        self.session.on(spotify.SessionEvent.PLAY_TOKEN_LOST,
+            self.play_token_lost)
 
         self.event_loop = spotify.EventLoop(self.session)
         self.event_loop.start()
@@ -268,6 +270,12 @@ class Ripper(threading.Thread):
         elif session.connection.state is spotify.ConnectionState.LOGGED_OUT:
             self.logged_in.clear()
             self.logged_out.set()
+
+    def play_token_lost(self, session):
+        print("\n"  + Fore.RED + "Play token lost, aborting..." + Fore.RESET)
+        self.session.player.play(False)
+        self.clean_up_partial()
+        self.finished = True
 
     def on_end_of_track(self, session):
         self.session.player.play(False)

--- a/spotify_ripper/ripper.py
+++ b/spotify_ripper/ripper.py
@@ -46,7 +46,7 @@ class Ripper(threading.Thread):
 
         config = spotify.Config()
 
-        default_dir = norm_path(os.path.join(os.path.expanduser("~"), ".spotify-ripper"))
+        default_dir = default_settings_dir()
 
         # application key location
         if args.key is not None:

--- a/spotify_ripper/songlibrary.py
+++ b/spotify_ripper/songlibrary.py
@@ -44,7 +44,6 @@ class SongLibrary():
             for fname in files:
                 mp3_file = os.path.join(root, fname)
                 artist, album, title = get_id3_metadata(mp3_file)
-
                 self.musiclibrary[artist][album][title] = mp3_file
 
     def contains_track(self, artist, album, title):

--- a/spotify_ripper/songlibrary.py
+++ b/spotify_ripper/songlibrary.py
@@ -12,7 +12,6 @@ from spotify_ripper.targetprovider import *
 
 
 class SongLibrary():
-
     attic = 'attic'
     target_provider = None
     musiclibrary = None
@@ -25,7 +24,7 @@ class SongLibrary():
 
     def __readlibrary(self):
         includes = ['*.mp3']
-        excludes = ["*"+self.attic+"*"]
+        excludes = ["*" + self.attic + "*"]
 
         # transform glob patterns to regular expressions
         includes = r'|'.join([fnmatch.translate(x) for x in includes])
@@ -62,7 +61,6 @@ class SongLibrary():
 
 
 class PlaylistLibrary(SongLibrary):
-
     playlist = None
     new_tracks = None
 
@@ -111,5 +109,5 @@ class PlaylistLibrary(SongLibrary):
             for ablum, tf in atf.items():
                 for title, filename in tf.items():
                     attic_file = os.path.join(attic_dir, os.path.basename(filename))
-                    print(Fore.MAGENTA + "Archiving "+filename + " to " + attic_file + Fore.RESET)
+                    print(Fore.MAGENTA + "Archiving " + filename + " to " + attic_file + Fore.RESET)
                     shutil.move(filename, attic_file)

--- a/spotify_ripper/targetprovider.py
+++ b/spotify_ripper/targetprovider.py
@@ -23,15 +23,20 @@ class TargetProvider():
     def get_track_metadata(self, track):
         args = self.args
 
-        artist = to_ascii(args, escape_filename_part(', '.join(tas.name for tas in track.artists)))
-        album = to_ascii(args, escape_filename_part(track.album.name))
-        track_name = to_ascii(args, escape_filename_part(track.name))
+        on_error = 'replace' if args.ascii_path_only else 'ignore'
+        album = to_ascii(args, track.album.name, on_error)
+        artist = to_ascii(args, ', '.join(tas.name for tas in track.artists), on_error)
+        track_name = to_ascii(args, track.name, on_error)
 
         return artist, album, track_name
 
     def get_mp3_file(self, idx, artist, album, track_name):
         args = self.args
         base_dir = self.get_base_dir()
+
+        artist = to_ascii(args, escape_filename_part(artist))
+        album = to_ascii(args, escape_filename_part(album))
+        track_name = to_ascii(args, escape_filename_part(track_name))
 
         if args.flat:
             mp3_file = to_ascii(args, os.path.join(base_dir, artist + " - " + track_name + ".mp3"))

--- a/spotify_ripper/targetprovider.py
+++ b/spotify_ripper/targetprovider.py
@@ -24,7 +24,7 @@ class TargetProvider():
     def get_track_metadata(self, track):
         args = self.args
 
-        artist = to_ascii(args, escape_filename_part(track.artists[0].name))
+        artist = to_ascii(args, escape_filename_part(', '.join(tas.name for tas in track.artists))
         album = to_ascii(args, escape_filename_part(track.album.name))
         track_name = to_ascii(args, escape_filename_part(track.name))
 

--- a/spotify_ripper/targetprovider.py
+++ b/spotify_ripper/targetprovider.py
@@ -4,7 +4,6 @@ from spotify_ripper.utils import norm_path, to_ascii, escape_filename_part
 
 
 class TargetProvider():
-
     args = None
 
     def __init__(self, args):
@@ -24,7 +23,7 @@ class TargetProvider():
     def get_track_metadata(self, track):
         args = self.args
 
-        artist = to_ascii(args, escape_filename_part(', '.join(tas.name for tas in track.artists))
+        artist = to_ascii(args, escape_filename_part(', '.join(tas.name for tas in track.artists)))
         album = to_ascii(args, escape_filename_part(track.album.name))
         track_name = to_ascii(args, escape_filename_part(track.name))
 
@@ -58,7 +57,6 @@ class TargetProvider():
 
 
 class PlaylistTargetProvider(TargetProvider):
-
     args = None
     playlist = None
 

--- a/spotify_ripper/utils.py
+++ b/spotify_ripper/utils.py
@@ -178,7 +178,8 @@ def format_time(seconds, total=None, short=False):
         if seconds < 60:
             return u'   {0:02d}s'.format(seconds)
 
-        for i in xrange(len(units) - 1):
+        #xrange won't work in Python3
+        for i in range(len(units) - 1):
             unit1, limit1 = units[i]
             unit2, limit2 = units[i + 1]
             if seconds >= limit1:

--- a/spotify_ripper/utils.py
+++ b/spotify_ripper/utils.py
@@ -31,6 +31,7 @@ def escape_filename_part(part):
     part = re.sub(r"(^\.+\s*|(?<=\.)\.+|\s*\.+$)", r'', part)
     return part
 
+
 def to_ascii(args, _str, on_error='ignore'):
     """convert unicode to ascii if necessary"""
     # python 3 renamed unicode to str
@@ -58,7 +59,6 @@ def rm_file(file_name):
         if e.errno != errno.ENOENT:
             print(Fore.YELLOW + "Warning: error while trying to remove file " + file_name + Fore.RESET)
             print(str(e))
-
 
 
 def default_settings_dir():
@@ -178,7 +178,7 @@ def format_time(seconds, total=None, short=False):
         if seconds < 60:
             return u'   {0:02d}s'.format(seconds)
 
-        #xrange won't work in Python3
+        # xrange won't work in Python3
         for i in range(len(units) - 1):
             unit1, limit1 = units[i]
             unit2, limit2 = units[i + 1]

--- a/spotify_ripper/utils.py
+++ b/spotify_ripper/utils.py
@@ -52,6 +52,9 @@ def rm_file(file_name):
             print(Fore.YELLOW + "Warning: error while trying to remove file " + file_name + Fore.RESET)
             print(str(e))
 
+def default_settings_dir():
+    return norm_path(os.path.join(os.path.expanduser("~"), ".spotify-ripper"))
+
 KB_BYTES = 1024
 '''Number of bytes per KB (2^10)'''
 MB_BYTES = 1048576

--- a/spotify_ripper/utils.py
+++ b/spotify_ripper/utils.py
@@ -2,7 +2,8 @@
 
 from __future__ import unicode_literals
 
-import os, sys
+from colorama import Fore, Style
+import os, sys, errno
 import re
 
 def print_str(str):
@@ -41,6 +42,15 @@ def to_ascii(args, _str):
             return _str.encode('ascii', 'ignore').decode("utf-8")
         else:
             return _str
+
+def rm_file(file_name):
+    try:
+        os.remove(file_name)
+    except OSError as e:
+        # don't need to print a warning if the file doesn't exist
+        if e.errno != errno.ENOENT:
+            print(Fore.YELLOW + "Warning: error while trying to remove file " + file_name + Fore.RESET)
+            print(str(e))
 
 KB_BYTES = 1024
 '''Number of bytes per KB (2^10)'''


### PR DESCRIPTION
Hi,

I saw you wrote a spotify ripper using the pyspotify 2 library. I decided to port my playlist handling feature from my old ripper to your new tool. The songlibrary scans the download dir for mp3 files and matches them with the newly ripped ones. Further in playlist mode, the idx/targetfile name is updated and missing entries are moved into the attic.

I used Python3 for testing so there you be one or two places which might nor work with Python 2.

Sorry, I'm not very good with Python.

Best regrads
wolkenschieber