### PR TITLE
Opus VBR / -q setting

### DIFF
--- a/spotify_ripper/main.py
+++ b/spotify_ripper/main.py
@@ -57,7 +57,7 @@ def main(prog_args=sys.argv[1:]):
     # load config file, overwriting any defaults
     defaults = {
         "bitrate": "320",
-		"stream-quality: 320"
+        "quality": "320",
         "vbr": "0",
     }
     defaults = load_config(args, defaults)
@@ -107,7 +107,7 @@ def main(prog_args=sys.argv[1:]):
     parser.add_argument('-m', '--pcm', action='store_true', help='Saves a .pcm file with the raw PCM data')
     parser.add_argument('-o', '--overwrite', action='store_true', help='Overwrite existing MP3 files [Default=skip]')
     encoding_group.add_argument('--opus', action='store_true', help='Rip songs to Ogg Opus encoding instead of MP3')
-	parser.add_argument('-Q', '--stream-quality', choices=['160', '320', '96'], help='Spotify stream bitrate preference [Default=320]')
+    parser.add_argument('-Q', '--quality', choices=['160', '320', '96'], help='Spotify stream bitrate preference [Default=320]')
     parser.add_argument('-s', '--strip-colors', action='store_true', help='Strip coloring from output[Default=colors]')
     parser.add_argument('-v', '--vbr', help='VBR quality setting or target bitrate for Opus [Default=0]')
     parser.add_argument('-V', '--version', action='version', version=prog_version)
@@ -184,7 +184,7 @@ def main(prog_args=sys.argv[1:]):
         return ""
 
     print(Fore.YELLOW + "  Encoding output:\t" + Fore.RESET + encoding_output_str())
-    print(Fore.YELLOW + "  Spotify bitrate:\t" + Fore.RESET + args.stream_quality + " kbps")
+    print(Fore.YELLOW + "  Spotify bitrate:\t" + Fore.RESET + args.quality + " kbps")
 
     def unicode_support_str():
         if args.ascii_path_only:

--- a/spotify_ripper/main.py
+++ b/spotify_ripper/main.py
@@ -57,6 +57,7 @@ def main(prog_args=sys.argv[1:]):
     # load config file, overwriting any defaults
     defaults = {
         "bitrate": "320",
+		"stream-quality: 320"
         "vbr": "0",
     }
     defaults = load_config(args, defaults)
@@ -71,7 +72,7 @@ def main(prog_args=sys.argv[1:]):
     search for tracks to rip: spotify-ripper -l -b 160 -o "album:Rumours track:'the chain'"
     ''')
 
-    # create group to prevent to prevent user from using both the -l and -u option
+    # create group to prevent user from using both the -l and -u option
     is_user_set = defaults.get('user') is not None
     is_last_set = defaults.get('last') is True
     if is_user_set or is_last_set:
@@ -91,8 +92,8 @@ def main(prog_args=sys.argv[1:]):
     prog_version = pkg_resources.require("spotify-ripper")[0].version
     parser.add_argument('-a', '--ascii', action='store_true', help='Convert the file name and the metadata tags to ASCII encoding [Default=utf-8]')
     parser.add_argument('-A', '--ascii-path-only', action='store_true', help='Convert the file name (but not the metadata tags) to ASCII encoding [Default=utf-8]')
-    parser.add_argument('-b', '--bitrate', choices=['160', '320', '96'], help='Bitrate rip quality [Default=320]')
-    parser.add_argument('-c', '--cbr', action='store_true', help='Lame CBR encoding [Default=VBR]')
+    parser.add_argument('-b', '--bitrate', help='CBR bitrate [Default=320]')
+    parser.add_argument('-c', '--cbr', action='store_true', help='CBR encoding [Default=VBR]')
     parser.add_argument('-d', '--directory', nargs=1, help='Base directory where ripped MP3s are saved [Default=cwd]')
     encoding_group.add_argument('--flac', action='store_true', help='Rip songs to lossless FLAC encoding instead of MP3')
     parser.add_argument('-f', '--flat', action='store_true', help='Save all songs to a single directory instead of organizing by album/artist/song')
@@ -106,8 +107,9 @@ def main(prog_args=sys.argv[1:]):
     parser.add_argument('-m', '--pcm', action='store_true', help='Saves a .pcm file with the raw PCM data')
     parser.add_argument('-o', '--overwrite', action='store_true', help='Overwrite existing MP3 files [Default=skip]')
     encoding_group.add_argument('--opus', action='store_true', help='Rip songs to Ogg Opus encoding instead of MP3')
+	parser.add_argument('-Q', '--stream-quality', choices=['160', '320', '96'], help='Spotify stream bitrate preference [Default=320]')
     parser.add_argument('-s', '--strip-colors', action='store_true', help='Strip coloring from output[Default=colors]')
-    parser.add_argument('-v', '--vbr', help='Lame VBR encoding quality setting [Default=0]')
+    parser.add_argument('-v', '--vbr', help='VBR quality setting or target bitrate for Opus [Default=0]')
     parser.add_argument('-V', '--version', action='version', version=prog_version)
     encoding_group.add_argument('--vorbis', action='store_true', help='Rip songs to Ogg Vorbis encoding instead of MP3')
     parser.add_argument('-r', '--remove-from-playlist', action='store_true', help='Delete tracks from playlist after successful ripping [Default=no]')
@@ -182,7 +184,7 @@ def main(prog_args=sys.argv[1:]):
         return ""
 
     print(Fore.YELLOW + "  Encoding output:\t" + Fore.RESET + encoding_output_str())
-    print(Fore.YELLOW + "  Spotify bitrate:\t" + Fore.RESET + args.bitrate + " kbps")
+    print(Fore.YELLOW + "  Spotify bitrate:\t" + Fore.RESET + args.stream_quality + " kbps")
 
     def unicode_support_str():
         if args.ascii_path_only:

--- a/spotify_ripper/ripper.py
+++ b/spotify_ripper/ripper.py
@@ -421,7 +421,7 @@ class Ripper(threading.Thread):
             if args.cbr:
                 self.rip_proc = Popen(["opusenc", "--quiet", "--cvbr", "--bitrate", str(int(args.bitrate) / 2), "--raw", "--raw-rate", "44100", "-", self.audio_file], stdin=PIPE)
             else:
-                self.rip_proc = Popen(["opusenc", "--quiet", "--vbr", "--bitrate", str(int(args.bitrate) / 2), "--raw", "--raw-rate", "44100", "-", self.audio_file], stdin=PIPE)
+                self.rip_proc = Popen(["opusenc", "--quiet", "--vbr", "--bitrate", args.vbr, "--raw", "--raw-rate", "44100", "-", self.audio_file], stdin=PIPE)
         elif args.output_type == "mp3":
             if args.cbr:
                 self.rip_proc = Popen(["lame", "--silent", "-cbr", "-b", args.bitrate, "-h", "-r", "-", self.audio_file], stdin=PIPE)

--- a/spotify_ripper/ripper.py
+++ b/spotify_ripper/ripper.py
@@ -82,7 +82,7 @@ class Ripper(threading.Thread):
             ('160', BitRate.BITRATE_160K),
             ('320', BitRate.BITRATE_320K),
             ('96', BitRate.BITRATE_96K)])
-        self.session.preferred_bitrate(bit_rates[args.bitrate])
+        self.session.preferred_bitrate(bit_rates[args.stream_quality])
         self.session.on(spotify.SessionEvent.CONNECTION_STATE_UPDATED,
             self.on_connection_state_changed)
         self.session.on(spotify.SessionEvent.END_OF_TRACK,

--- a/spotify_ripper/ripper.py
+++ b/spotify_ripper/ripper.py
@@ -82,7 +82,7 @@ class Ripper(threading.Thread):
             ('160', BitRate.BITRATE_160K),
             ('320', BitRate.BITRATE_320K),
             ('96', BitRate.BITRATE_96K)])
-        self.session.preferred_bitrate(bit_rates[args.stream_quality])
+        self.session.preferred_bitrate(bit_rates[args.quality])
         self.session.on(spotify.SessionEvent.CONNECTION_STATE_UPDATED,
             self.on_connection_state_changed)
         self.session.on(spotify.SessionEvent.END_OF_TRACK,

--- a/spotify_ripper/ripper.py
+++ b/spotify_ripper/ripper.py
@@ -419,9 +419,9 @@ class Ripper(threading.Thread):
                 self.rip_proc = Popen(["oggenc", "--quiet", "--raw", "-q", args.vbr, "-o", self.audio_file, "-"], stdin=PIPE)
         elif args.output_type == "opus":
             if args.cbr:
-                self.rip_proc = Popen(["opusenc", "--quiet", "--bitrate", str(int(args.bitrate) / 2), "--raw", "--raw-rate", "44100", "-", self.audio_file], stdin=PIPE)
+                self.rip_proc = Popen(["opusenc", "--quiet", "--cvbr", "--bitrate", str(int(args.bitrate) / 2), "--raw", "--raw-rate", "44100", "-", self.audio_file], stdin=PIPE)
             else:
-                self.rip_proc = Popen(["opusenc", "--quiet", "--vbr", "--comp",  args.vbr, "--raw", "--raw-rate", "44100", "-", self.audio_file], stdin=PIPE)
+                self.rip_proc = Popen(["opusenc", "--quiet", "--vbr", "--bitrate", str(int(args.bitrate) / 2), "--comp", args.vbr, "--raw", "--raw-rate", "44100", "-", self.audio_file], stdin=PIPE)
         elif args.output_type == "mp3":
             if args.cbr:
                 self.rip_proc = Popen(["lame", "--silent", "-cbr", "-b", args.bitrate, "-h", "-r", "-", self.audio_file], stdin=PIPE)

--- a/spotify_ripper/ripper.py
+++ b/spotify_ripper/ripper.py
@@ -421,7 +421,7 @@ class Ripper(threading.Thread):
             if args.cbr:
                 self.rip_proc = Popen(["opusenc", "--quiet", "--cvbr", "--bitrate", str(int(args.bitrate) / 2), "--raw", "--raw-rate", "44100", "-", self.audio_file], stdin=PIPE)
             else:
-                self.rip_proc = Popen(["opusenc", "--quiet", "--vbr", "--bitrate", str(int(args.bitrate) / 2), "--comp", args.vbr, "--raw", "--raw-rate", "44100", "-", self.audio_file], stdin=PIPE)
+                self.rip_proc = Popen(["opusenc", "--quiet", "--vbr", "--bitrate", str(int(args.bitrate) / 2), "--raw", "--raw-rate", "44100", "-", self.audio_file], stdin=PIPE)
         elif args.output_type == "mp3":
             if args.cbr:
                 self.rip_proc = Popen(["lame", "--silent", "-cbr", "-b", args.bitrate, "-h", "-r", "-", self.audio_file], stdin=PIPE)

--- a/spotify_ripper/utils.py
+++ b/spotify_ripper/utils.py
@@ -57,7 +57,7 @@ def default_settings_dir():
     return norm_path(os.path.join(os.path.expanduser("~"), ".spotify-ripper"))
 
 def calc_file_size(args, track):
-    return (int(args.bitrate) / 8) * track.duration
+    return (int(args.stream_quality) / 8) * track.duration
 
 # returns path of executable
 def which(program):

--- a/spotify_ripper/utils.py
+++ b/spotify_ripper/utils.py
@@ -57,7 +57,7 @@ def default_settings_dir():
     return norm_path(os.path.join(os.path.expanduser("~"), ".spotify-ripper"))
 
 def calc_file_size(args, track):
-    return (int(args.stream_quality) / 8) * track.duration
+    return (int(args.quality) / 8) * track.duration
 
 # returns path of executable
 def which(program):


### PR DESCRIPTION
Opus has no real "q" constant-quality setting yet, you have to specify a target bitrate in vbr mode, too. the --comp paramater specifies the codec complexity and thus encoding speed, it should always be set to 10 and is so by default (may need performance testing on slow cpu's like rpi 1 or mips devices)