### PR TITLE
Create playlists

### DIFF
--- a/spotify_ripper/progress.py
+++ b/spotify_ripper/progress.py
@@ -57,7 +57,7 @@ class Progress(object):
         self.total_size = 0
 
         # some duplicate work here, maybe cache this info beforehand?
-        for idx, track in enumerate(tracks):
+        for idx, (track, __) in enumerate(tracks):
             try:
                 track.load()
                 if track.availability != 1:


### PR DESCRIPTION
Short history:
Add hability to append a track to m3u playlists when have playlist information for given track.

Long history:

When we are getting the track information for playlists we also store playlist name in a tuple with `(<track>,<playlist info>)`, and at end of ripping we use that information to add the track to given playlist.

So, now instead just get all your files and lost the playlists, we can have both.

This refers to issue #85.