### PR TITLE
Add Vagrant file and Ubuntu provisioning script.

### DIFF
--- a/RUNME.sh
+++ b/RUNME.sh
@@ -1,0 +1,17 @@
+sudo apt-add-repository multiverse
+sudo apt-get update
+sudo apt-get -y install lame build-essential libffi-dev python-pip libffi-dev libssl-dev python-dev flac libav-tools faac libfdk-aac-dev automake autoconf vorbis-tools opus-tools
+# MP4/M4A (need to compile fdkaac from source)
+wget https://github.com/nu774/fdkaac/archive/v0.6.2.tar.gz
+tar xvf v0.6.2.tar.gz
+cd fdkaac-0.6.2
+autoreconf -i
+./configure
+sudo make install
+# Install libspotify
+wget https://developer.spotify.com/download/libspotify/libspotify-12.1.51-Linux-x86_64-release.tar.gz
+tar xvf libspotify-12.1.51-Linux-x86_64-release.tar.gz
+cd libspotify-12.1.51-Linux-x86_64-release/
+sudo make install prefix=/usr/local
+# Install spotify-ripper
+sudo -H pip install spotify-ripper

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,8 @@
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/trusty64"
+  config.vm.provision "shell", path: "RUNME.sh"
+  config.vm.provider "virtualbox" do |v|
+    v.memory = 4096
+  end
+end
+


### PR DESCRIPTION
I created a simple Vagrantfile and a Ubuntu provisioning script from the readme instructions. I have confirmed that this will create a working installation of spotify-ripper in a Ubuntu VM. The user will still have to manually load their Spotify app key file. Is this something you are interested in adding? The script can probably be improved a little. Feedback welcome. 
