### PR TITLE
added market and match-similar option + fix for incomp. track dection

### DIFF
--- a/spotify_ripper/main.py
+++ b/spotify_ripper/main.py
@@ -37,7 +37,7 @@ def load_config(defaults):
             to_array_options = [
                 "comment", "cover_file", "cover_embed", "directory", "fail_log", "format",
                 "genres", "grouping", "key", "user", "password", "log", "filter_albums"
-                "replace", "upper_words"]
+                "replace", "upper_words", "market", "match_similar_track_name"]
 
             # coerce boolean and none types
             config_items_new = {}
@@ -320,6 +320,15 @@ def main(prog_args=sys.argv[1:]):
     parser.add_argument(
         '--upper-words', action='store_true',
         help='Convert make all words of the filenames start with captial letters')
+    parser.add_argument(
+        '--market', nargs=1,
+        help='The Country (iso2 country code) the albums get fetched from the artists page. '
+             'if you not set this, you may get duplicate albums. [Default=any]')
+    parser.add_argument(
+        '--match-similar-track-name', action='store_true',
+        help='Avoid ripping a new file if one that starts with the same name '
+             'exits. currently compares until the first space, so if your filename'
+             'starts with a track number, this will skip existing tracks.')
     parser.add_argument(
         'uri', nargs="+",
         help='One or more Spotify URI(s) (either URI, a file of URIs or a '

--- a/spotify_ripper/utils.py
+++ b/spotify_ripper/utils.py
@@ -419,8 +419,13 @@ def is_partial(audio_file, track):
         return None
 
     audio_file_dur = audio_file_duration(audio_file)
+
+    if (audio_file_dur is None or
+           (track.duration/1000) > math.ceil(audio_file_dur)):
+    # there is a small difference between the track and the file duration,
+    # ceil the file duration up to be sure.
     return (audio_file_dur is None or
-        track.duration > (audio_file_dur * 1000))
+           (track.duration/1000) > math.ceil(audio_file_dur)*1.01)
 
 
 # borrowed from eyeD3

--- a/spotify_ripper/web.py
+++ b/spotify_ripper/web.py
@@ -43,12 +43,19 @@ class WebAPI(object):
         return 'https://spotifycharts.com/api/' + url_path
 
     # excludes 'appears on' albums for artist
-    def get_albums_with_filter(self, uri, filter):
-        def get_albums_json(offset, filter):
-            url = self.api_url(
+    def get_albums_with_filter(self, uri, filter, market):
+        def get_albums_json(offset, filter, market):
+            print(market)
+            if market == "any":
+                url = self.api_url(
+                        'artists/' + uri_tokens[2] +
+                        '/albums/?=album_type=' + filter +
+                        '&limit=50&offset=' + str(offset))
+            else:
+                url = self.api_url(
                     'artists/' + uri_tokens[2] +
                     '/albums/?=album_type=' + filter +
-                    '&limit=50&offset=' + str(offset))
+                    '&market='+market+'&limit=50&offset=' + str(offset))
             return self.request_json(url, "albums")
 
         # check for cached result
@@ -70,7 +77,7 @@ class WebAPI(object):
                 # rate limit if not first request
                 if total is None:
                     time.sleep(1.0)
-                albums = get_albums_json(offset, filter)
+                albums = get_albums_json(offset, filter,market)
                 if albums is None:
                     break
 


### PR DESCRIPTION
added two more options. also noticed that spotify-ripper redownloads some tracks over and over again, so i added some buffer to the length calculation.

feel free to change names as you like. README.md needs still updating.