### PR TITLE
Fix downloaded musics number bug.

### DIFF
--- a/spotify_ripper/ripper.py
+++ b/spotify_ripper/ripper.py
@@ -270,6 +270,7 @@ class Ripper(threading.Thread):
                         if is_partial(self.audio_file, track):
                             print("Overwriting partial file")
                         else:
+                            self.progress.track_idx += 1
                             print(
                                 Fore.YELLOW + "Skipping " +
                                 track.link.uri + Fore.RESET)


### PR DESCRIPTION
When skip an downloaded music the self.progress.track_idx variable not is incremented...

Now skipped musics are counted