### PR TITLE
Fix recognizable fill tag

### DIFF
--- a/spotify_ripper/utils.py
+++ b/spotify_ripper/utils.py
@@ -289,7 +289,7 @@ def format_track_string(ripper, format_string, idx, track):
     }
     fill_tags = {"idx", "index", "track_num", "track_idx",
                  "track_index", "disc_num", "disc_idx", "disc_index",
-                 "smart_num"}
+                 "smart_track_num"}
     prefix_tags = {"feat_artists", "featuring_artists"}
     paren_tags = {"track_name", "track"}
     for tag in tags.keys():


### PR DESCRIPTION
This program allows the smart track number tag, smart_track_num, as well as its variants, to be zero-padded.  However, in the utils.py file, smart_num is specified as a fill tag key instead of smart_track_num, which is a bug.  This causes any instance of, say, {smart_track_num:2} to be replaced with {smart_track_num/2} rather than, say, 07 or 116.