### PR TITLE
Metadata/fill tag improvements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,7 +81,7 @@ Command Line
 
 .. code::
 
-    usage: spotify-ripper [-h] [-S SETTINGS] [-a] [--aac] [--alac]
+    usage: spotify-ripper [-h] [-S SETTINGS] [-a] [--aac] [--alac] [--all-artists]
                           [--artist-album-type ARTIST_ALBUM_TYPE]
                           [--artist-album-market ARTIST_ALBUM_MARKET] [-A]
                           [-b BITRATE] [-c] [--comp COMP] [--comment COMMENT]
@@ -114,6 +114,7 @@ Command Line
       -a, --ascii           Convert the file name and the metadata tags to ASCII encoding [Default=utf-8]
       --aac                 Rip songs to AAC format with FreeAAC instead of MP3
       --alac                Rip songs to Apple Lossless format instead of MP3
+      --all-artists         Store all artists, rather than just the main artist, in the track's metadata tag
       --artist-album-type ARTIST_ALBUM_TYPE
                             Only load albums of specified types when passing a Spotify artist URI [Default=album,single,ep,compilation,appears_on]
       --artist-album-market ARTIST_ALBUM_MARKET

--- a/spotify_ripper/main.py
+++ b/spotify_ripper/main.py
@@ -166,6 +166,10 @@ def main(prog_args=sys.argv[1:]):
         '--alac', action='store_true',
         help='Rip songs to Apple Lossless format instead of MP3')
     parser.add_argument(
+        '--all-artists', action='store_true',
+        help='Store all artists, rather than just the main artist, in the '
+             'track\'s metadata tag')
+    parser.add_argument(
         '--artist-album-type', nargs=1,
         help='Only load albums of specified types when passing a Spotify '
              'artist URI [Default=album,single,ep,compilation,appears_on]')

--- a/spotify_ripper/tags.py
+++ b/spotify_ripper/tags.py
@@ -54,6 +54,7 @@ def set_metadata_tags(args, audio_file, idx, track, ripper):
         artists = ", ".join([artist.name for artist in track.artists]) \
             if args.all_artists else track.artists[0].name
         artists_ascii = to_ascii(artists, on_error)
+        album_artist = to_ascii(track.album.artist.name, on_error)
         title = to_ascii(track.name, on_error)
 
         # the comment tag can be formatted
@@ -127,6 +128,11 @@ def set_metadata_tags(args, audio_file, idx, track, ripper):
             audio.tags.add(
                 id3.TPE1(text=[tag_to_ascii(artists, artists_ascii)],
                          encoding=3))
+            if album_artist is not None:
+                audio.tags.add(
+                    id3.TPE2(text=[tag_to_ascii(
+                                       track.album.artist.name, album_artist)],
+                             encoding=3))
             audio.tags.add(id3.TDRC(text=[str(track.album.year)],
                                     encoding=3))
             audio.tags.add(
@@ -186,6 +192,11 @@ def set_metadata_tags(args, audio_file, idx, track, ripper):
             id3_dict.add(
                 id3.TPE1(text=[tag_to_ascii(artists, artists_ascii)],
                          encoding=3))
+            if album_artist is not None:
+                id3_dict.add(
+                    id3.TPE2(text=[tag_to_ascii(
+                                       track.album.artist.name, album_artist)],
+                             encoding=3))
             id3_dict.add(id3.TDRC(text=[str(track.album.year)],
                                   encoding=3))
             id3_dict.add(
@@ -239,6 +250,9 @@ def set_metadata_tags(args, audio_file, idx, track, ripper):
                 audio.tags["ALBUM"] = tag_to_ascii(track.album.name, album)
             audio.tags["TITLE"] = tag_to_ascii(track.name, title)
             audio.tags["ARTIST"] = tag_to_ascii(artists, artists_ascii)
+            if album_artist is not None:
+                audio.tags["ALBUMARTIST"] = \
+                    tag_to_ascii(track.album.artist.name, album_artist)
             audio.tags["DATE"] = str(track.album.year)
             audio.tags["YEAR"] = str(track.album.year)
             audio.tags["DISCNUMBER"] = str(track.disc)
@@ -272,6 +286,9 @@ def set_metadata_tags(args, audio_file, idx, track, ripper):
                 audio.tags["\xa9alb"] = tag_to_ascii(track.album.name, album)
             audio["\xa9nam"] = tag_to_ascii(track.name, title)
             audio.tags["\xa9ART"] = tag_to_ascii(artists, artists_ascii)
+            if album_artist is not None:
+                audio.tags["aART"] = \
+                    tag_to_ascii(track.album.artist.name, album_artist)
             audio.tags["\xa9day"] = str(track.album.year)
             audio.tags["disk"] = [(track.disc, num_discs)]
             audio.tags["trkn"] = [(track.index, num_tracks)]
@@ -299,6 +316,9 @@ def set_metadata_tags(args, audio_file, idx, track, ripper):
                 audio.tags[b"\xa9alb"] = tag_to_ascii(track.album.name, album)
             audio[b"\xa9nam"] = tag_to_ascii(track.name, title)
             audio.tags[b"\xa9ART"] = tag_to_ascii(artists, artists_ascii)
+            if album_artist is not None:
+                audio.tags[str("aART")] = tag_to_ascii(
+                    track.album.artist.name, album_artist)
             audio.tags[b"\xa9day"] = str(track.album.year)
             audio.tags[str("disk")] = (track.disc, num_discs)
             audio.tags[str("trkn")] = (track.index, num_tracks)
@@ -378,6 +398,9 @@ def set_metadata_tags(args, audio_file, idx, track, ripper):
         print(Fore.YELLOW + "Setting artist: " + artists_ascii + Fore.RESET)
         if album is not None:
             print(Fore.YELLOW + "Setting album: " + album + Fore.RESET)
+        if album_artist is not None:
+            print(Fore.YELLOW + "Setting album artist: " + album_artist +
+                  Fore.RESET)
         print(Fore.YELLOW + "Setting title: " + title + Fore.RESET)
         print(Fore.YELLOW + "Setting track info: (" +
               str(track.index) + ", " + str(num_tracks) + ")" + Fore.RESET)

--- a/spotify_ripper/tags.py
+++ b/spotify_ripper/tags.py
@@ -51,7 +51,9 @@ def set_metadata_tags(args, audio_file, idx, track, ripper):
         audio = None
         on_error = 'replace' if args.ascii_path_only else 'ignore'
         album = to_ascii(track.album.name, on_error)
-        artist = to_ascii(track.artists[0].name, on_error)
+        artists = ", ".join([artist.name for artist in track.artists]) \
+            if args.all_artists else track.artists[0].name
+        artists_ascii = to_ascii(artists, on_error)
         title = to_ascii(track.name, on_error)
 
         # the comment tag can be formatted
@@ -123,7 +125,7 @@ def set_metadata_tags(args, audio_file, idx, track, ripper):
                 id3.TIT2(text=[tag_to_ascii(track.name, title)],
                          encoding=3))
             audio.tags.add(
-                id3.TPE1(text=[tag_to_ascii(track.artists[0].name, artist)],
+                id3.TPE1(text=[tag_to_ascii(artists, artists_ascii)],
                          encoding=3))
             audio.tags.add(id3.TDRC(text=[str(track.album.year)],
                                     encoding=3))
@@ -182,7 +184,7 @@ def set_metadata_tags(args, audio_file, idx, track, ripper):
                 id3.TIT2(text=[tag_to_ascii(track.name, title)],
                          encoding=3))
             id3_dict.add(
-                id3.TPE1(text=[tag_to_ascii(track.artists[0].name, artist)],
+                id3.TPE1(text=[tag_to_ascii(artists, artists_ascii)],
                          encoding=3))
             id3_dict.add(id3.TDRC(text=[str(track.album.year)],
                                   encoding=3))
@@ -236,7 +238,7 @@ def set_metadata_tags(args, audio_file, idx, track, ripper):
             if album is not None:
                 audio.tags["ALBUM"] = tag_to_ascii(track.album.name, album)
             audio.tags["TITLE"] = tag_to_ascii(track.name, title)
-            audio.tags["ARTIST"] = tag_to_ascii(track.artists[0].name, artist)
+            audio.tags["ARTIST"] = tag_to_ascii(artists, artists_ascii)
             audio.tags["DATE"] = str(track.album.year)
             audio.tags["YEAR"] = str(track.album.year)
             audio.tags["DISCNUMBER"] = str(track.disc)
@@ -269,7 +271,7 @@ def set_metadata_tags(args, audio_file, idx, track, ripper):
             if album is not None:
                 audio.tags["\xa9alb"] = tag_to_ascii(track.album.name, album)
             audio["\xa9nam"] = tag_to_ascii(track.name, title)
-            audio.tags["\xa9ART"] = tag_to_ascii(track.artists[0].name, artist)
+            audio.tags["\xa9ART"] = tag_to_ascii(artists, artists_ascii)
             audio.tags["\xa9day"] = str(track.album.year)
             audio.tags["disk"] = [(track.disc, num_discs)]
             audio.tags["trkn"] = [(track.index, num_tracks)]
@@ -296,8 +298,7 @@ def set_metadata_tags(args, audio_file, idx, track, ripper):
             if album is not None:
                 audio.tags[b"\xa9alb"] = tag_to_ascii(track.album.name, album)
             audio[b"\xa9nam"] = tag_to_ascii(track.name, title)
-            audio.tags[b"\xa9ART"] = tag_to_ascii(
-                track.artists[0].name, artist)
+            audio.tags[b"\xa9ART"] = tag_to_ascii(artists, artists_ascii)
             audio.tags[b"\xa9day"] = str(track.album.year)
             audio.tags[str("disk")] = (track.disc, num_discs)
             audio.tags[str("trkn")] = (track.index, num_tracks)
@@ -374,7 +375,7 @@ def set_metadata_tags(args, audio_file, idx, track, ripper):
 
         # log id3 tags
         print("-" * 79)
-        print(Fore.YELLOW + "Setting artist: " + artist + Fore.RESET)
+        print(Fore.YELLOW + "Setting artist: " + artists_ascii + Fore.RESET)
         if album is not None:
             print(Fore.YELLOW + "Setting album: " + album + Fore.RESET)
         print(Fore.YELLOW + "Setting title: " + title + Fore.RESET)

--- a/spotify_ripper/utils.py
+++ b/spotify_ripper/utils.py
@@ -178,11 +178,13 @@ def format_track_string(ripper, format_string, idx, track):
 
     track_artist = to_ascii(
         escape_filename_part(track.artists[0].name))
-    track_artists = to_ascii(", ".join(
-        [artist.name for artist in track.artists]))
+    track_artists = to_ascii(
+        escape_filename_part(", ".join(
+            [artist.name for artist in track.artists])))
     if len(track.artists) > 1:
-        featuring_artists = to_ascii(", ".join(
-            [artist.name for artist in track.artists[1:]]))
+        featuring_artists = to_ascii(
+            escape_filename_part(", ".join(
+                [artist.name for artist in track.artists[1:]])))
     else:
         featuring_artists = ""
 
@@ -195,7 +197,8 @@ def format_track_string(ripper, format_string, idx, track):
         artist_array = \
             ripper.web.get_artists_on_album(current_album.link.uri)
         if artist_array is not None:
-            album_artists_web = to_ascii(", ".join(artist_array))
+            album_artists_web = to_ascii(
+                escape_filename_part(", ".join(artist_array)))
 
     album = to_ascii(escape_filename_part(track.album.name))
     track_name = to_ascii(escape_filename_part(track.name))

--- a/spotify_ripper/utils.py
+++ b/spotify_ripper/utils.py
@@ -171,6 +171,8 @@ def format_track_string(ripper, format_string, idx, track):
         track.load()
     if not track.album.is_loaded:
         track.album.load()
+    if current_album is None:
+        current_album = track.album
     album_browser = track.album.browse()
     album_browser.load()
 
@@ -185,13 +187,11 @@ def format_track_string(ripper, format_string, idx, track):
         featuring_artists = ""
 
     album_artist = to_ascii(
-        current_album.artist.name
-        if current_album is not None else track_artist)
+        escape_filename_part(current_album.artist.name))
     album_artists_web = track_artists
 
     # only retrieve album_artist_web if it exists in the format string
-    if (current_album is not None and
-            format_string.find("{album_artists_web}") >= 0):
+    if format_string.find("{album_artists_web}") >= 0:
         artist_array = \
             ripper.web.get_artists_on_album(current_album.link.uri)
         if artist_array is not None:


### PR DESCRIPTION
This PR consists of the following changes:

1. **An added option that allows all track artists to be stored in the file's metadata tag**

   Only the first artist in the list of track artists is stored in a metadata tag, but some users might want every artist who made the track to be included in the metadata tag. This change adds an option to override the default behavior described here.

2. **Inclusion of album artist in the file's metadata tag**

   The album artist is not set in the metadata tags, which can be a problem if a user wants to sort tracks in a media player by album artist and would like to have tracks that are part of compilations to stay together. This change introduces the setting of album artists in metadata tags so that tracks can be properly sorted by album artist in media players.

3. **The use of the actual album artist for the album artist fill tag in all rip scenarios**

   The program can set the album artist fill tag to the actual album artist, but only when an album URI is used. Otherwise, the tag is set to the artist of the track (i.e., the album artist and track artist fill tags correspond to the same value). This change guarantees that the album artist fill tag is set to the actual album artist, no matter what type of URI is used.

4. **Bug fixes**

   There are some fill tags that have bad substitutions because of values that were not escaped. This change fixes that issue.